### PR TITLE
Add AMR-Wind-generated outputs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# AMR-Wind output folders and files
+bndry_files/
+plt*/
+chk*/
+post_processing/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
[DRAFT] (this repo doesn't seem to have a formal draft PR feature)

Addressing issue #6 

AMR-Wind generates many folders and files as outputs. I'm proposing adding these to the .gitignore to keep tracking source code easier.

Questions: 
- @paulf81 Any reason that we should not be adding these to the .gitignore (i.e. are there any outputs that we think should stay in the repository)?
- @michaeljbrazell Any other major output directories that I should be adding to the .gitignore? The ones I've added so far are generated by the 001 precursor, but are there any other obvious ones that might get generated? These can also be added as we go.